### PR TITLE
AT_045.005 | Main page > Section with 8-day forecast. Check display of eight days from current date

### DIFF
--- a/cypress/e2e/arkGroup.cy.js
+++ b/cypress/e2e/arkGroup.cy.js
@@ -116,5 +116,21 @@ it('AT_010.004 | Marketplace > Verify all orange links on the page', () => {
           }      
         })
       })
+    
+    it('AT_045.005 | Main page > Section with 8-day forecast. Check display of eight days from current date', () => {
+      cy.visit('https://openweathermap.org/')  
+      cy.get('.daily-container ul.day-list li > span')
+        .then($elArr => {
+          expect($elArr).to.have.length(8)
+          const startDate = new Date().getTime()
+          const formatDate = { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'UTC' };
+          let itemDate         
+          cy.wrap($elArr).each(($el, $i) => {
+            itemDate = startDate + 86400000 * $i
+            itemDate = new Date(itemDate).toLocaleDateString('en', formatDate)
+            cy.wrap($el).should('include.text', itemDate)
+          })  
+        })
+      })
 
 });


### PR DESCRIPTION
https://trello.com/c/DNYA9AEy/399-at045005-main-page-section-with-8-day-forecast-check-display-of-eight-days-from-current-date