### PR TITLE
002.000 Header > Clicking the logo. 

### DIFF
--- a/cypress/e2e/groupTeachers.cy.js
+++ b/cypress/e2e/groupTeachers.cy.js
@@ -63,5 +63,10 @@ describe('group jsTeachers', () => {
       .should('be.visible')
   })
 
+  it('1.TV.002.000| Header > Clicking the logo', () => { 
+    cy.visit('https://openweathermap.org/guide')
+    cy.get('li[class="logo"]').click()
+    cy.url().should('eq', 'https://openweathermap.org/')
 
+  })
 })


### PR DESCRIPTION
Clicking the logo (from any page, except of the Main one) in the top left corner redirecting a user to the Main page https://openweathermap.org.