### PR TITLE
RF | Footer > After clicking on the `Website terms and conditions` in the footer the expected page is opened

### DIFF
--- a/cypress/e2e/OLD/jScript_group.cy.js
+++ b/cypress/e2e/OLD/jScript_group.cy.js
@@ -30,7 +30,7 @@ describe('Group jScript_group', () => {
         cy.get('.post-list .post').should('have.length', this.data.blogPagePostsQuantity);
     });
 
-    it('AT_030.001 | Footer > After clicking on the "Website terms and conditions" in the footer the expected page is opened', function () {
+    it.skip('AT_030.001 | Footer > After clicking on the "Website terms and conditions" in the footer the expected page is opened', function () {
         cy.get('[href*="use.pdf"]').invoke('removeAttr', 'target').click({force: true});
         cy.url().should('include','terms_and_conditions_of_use.pdf');
     });

--- a/cypress/e2e/footerSpec.cy.js
+++ b/cypress/e2e/footerSpec.cy.js
@@ -1,0 +1,23 @@
+/// <reference types="cypress" />
+ 
+import Header from "../pageObjects/Header.js"
+import Footer from "../pageObjects/Footer.js"
+ 
+const header = new Header();
+const footer = new Footer();
+ 
+describe('Footer test suite', () => {
+
+    beforeEach(function() {
+        cy.fixture('footer').then(data => {
+            this.data = data;
+        });
+        cy.visit('/');
+    });
+
+    it('AT_030.001 | Footer > After clicking on the "Website terms and conditions" in the footer the expected page is opened', function () {
+        footer.elements.getWebsiteTermsAndConditions().invoke('removeAttr', 'target').click();
+        
+        cy.url().should('be.equal',this.data.websiteTermsUrl);
+    });
+});

--- a/cypress/e2e/footerSpec.cy.js
+++ b/cypress/e2e/footerSpec.cy.js
@@ -1,9 +1,7 @@
 /// <reference types="cypress" />
  
-import Header from "../pageObjects/Header.js"
 import Footer from "../pageObjects/Footer.js"
  
-const header = new Header();
 const footer = new Footer();
  
 describe('Footer test suite', () => {

--- a/cypress/fixtures/footer.json
+++ b/cypress/fixtures/footer.json
@@ -1,0 +1,4 @@
+{
+    "websiteTermsUrl": "https://openweather.co.uk/storage/app/media/Terms/Openweather_website_terms_and_conditions_of_use.pdf",
+    "websiteTerms": "Website terms and conditions of use"
+}

--- a/cypress/pageObjects/Footer.js
+++ b/cypress/pageObjects/Footer.js
@@ -1,0 +1,6 @@
+class Footer {
+    elements = {
+        getWebsiteTermsAndConditions: () => cy.get('[href*="use.pdf"]')
+    }
+}
+export default Footer;


### PR DESCRIPTION
https://trello.com/c/59t3PpVP/726-rf-footer-after-clicking-on-the-website-terms-and-conditions-in-the-footer-the-expected-page-is-opened