### PR TITLE
ERR | Widgets page test suite > AT_021.007 | Footer > Widgets> Verify popup windows with info appear after clicking "Get code" buttons

### DIFF
--- a/cypress/e2e/widgetsPageSpec.cy.js
+++ b/cypress/e2e/widgetsPageSpec.cy.js
@@ -66,12 +66,14 @@ describe('Widgets page test suite', () => {
         widgetsPage.elements.getApiInputFieldErrMessage().should('have.text', this.data.apiInputFielValidMessage)
     });
 
-    it.skip('AT_021.007 | Footer > Widgets> Verify popup windows with info appear after clicking "Get code" buttons', function() {
+    it('AT_021.007 | Footer > Widgets> Verify popup windows with info appear after clicking "Get code" buttons', function() {
         header.clickSignInMenuLink()
         singInPage.signIn(this.data.userData1.login, this.data.userData1.password)
         header.clickUserDropDownMenu()
         header.clickMyApiKyesLink()
         cy.url().should('contain', this.keys.urn)
+        apiKeysPage.elements.getAPIkyes().should('have.length', 1)
+        apiKeysPage.elements.getNamesAPIkeys().should('have.text', this.keys.keyNames.defaultNameKey)
         apiKeysPage.elements.getCreateKeyField().type(this.keys.keyNames.newNameKey)
         apiKeysPage.clickGenerateButton()
 


### PR DESCRIPTION
https://trello.com/c/9iTH3klu/906-err-widgets-page-test-suite-at021007-footer-widgets-verify-popup-windows-with-info-appear-after-clicking-get-code-buttons